### PR TITLE
Resolve type error when using results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@stratocanvas/easy-ort",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@stratocanvas/easy-ort",
-			"version": "1.2.0",
+			"version": "1.2.1",
 			"license": "MIT",
 			"dependencies": {
 				"sharp": "^0.33.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@stratocanvas/easy-ort",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"description": "Easy-to-use ONNX Runtime wrapper for common ML tasks",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/src/types/results.ts
+++ b/src/types/results.ts
@@ -1,29 +1,23 @@
-export interface DetectionItem {
-    label: string;
-    box: number[];
-    confidence: number;
-    squareness: number;
-}
+export type TaskResult = DetectionResult | ClassificationResult | EmbeddingResult;
 
 export interface DetectionResult {
-    detections: DetectionItem[];
-}
-
-export interface ClassificationItem {
+  detections: {
     label: string;
+    box: [number, number, number, number];
     confidence: number;
+    squareness: number;
+  }[];
 }
 
 export interface ClassificationResult {
-    classifications: ClassificationItem[];
+  classifications: {
+    label: string;
+    confidence: number;
+  }[];
 }
 
-export type EmbeddingResult = number[];
+export type EmbeddingResult = number[][];
 
-// 각 작업별 결과 배열 타입
-export type DetectionResults = DetectionResult[];
-export type ClassificationResults = ClassificationResult[];
-export type EmbeddingResults = EmbeddingResult[];
-
-// Union type for all possible task results
-export type TaskResult = DetectionResults | ClassificationResults | EmbeddingResults; 
+export function isDetectionResult(result: TaskResult): result is DetectionResult {
+  return 'detections' in result;
+}


### PR DESCRIPTION
## Resolve type error when using result
### Overview
- Fixed `Property 'detections' does not exist on type 'TaskResult'.   Property 'detections' does not exist on type 'ClassificationResult'.` error when using `result.detections` 
### Details
- Define EmbeddingResult type as number[][]
- Utilize `TaskBuilder` generic types to ensure type safety

### Related Commits
 https://github.com/stratocanvas/easy-ort/commit/bff915df6c7707b8fba545ef4ef1d44810eb6641 **[fix: type error when using detections[] of result](https://github.com/stratocanvas/easy-ort/commit/bff915df6c7707b8fba545ef4ef1d44810eb6641)**